### PR TITLE
エリアコメントの開始と終了が同一文字列だとコメントと認識されないので修正。

### DIFF
--- a/core/stepcounter/src/main/java/jp/sf/amateras/stepcounter/DefaultStepCounter.java
+++ b/core/stepcounter/src/main/java/jp/sf/amateras/stepcounter/DefaultStepCounter.java
@@ -156,7 +156,7 @@ public class DefaultStepCounter implements StepCounter, Cutter {
 			String end   = area.getEndString();
 
 			int index = line.indexOf(start);
-			if(index==0 && line.indexOf(end,index)==line.length()-end.length()){
+			if(index==0 && line.indexOf(end,index+start.length())==line.length()-end.length()){
 				return true;
 			}
 		}
@@ -173,7 +173,7 @@ public class DefaultStepCounter implements StepCounter, Cutter {
 			String end   = area.getEndString();
 
 			int index = line.indexOf(start);
-			if(index>=0 && line.indexOf(end,index)<0){
+			if(index>=0 && line.indexOf(end,index+start.length())<0){
 				return area;
 			}
 		}


### PR DESCRIPTION
Smalltalk だと正しく動かないようだったので。
が、エスケープされたクォートがあると依然として正しく動きません。
Smalltalk は専用のステップカウンタ実装が必要なようです。
